### PR TITLE
Improve performance. 

### DIFF
--- a/docs/source/module/crypto.rst
+++ b/docs/source/module/crypto.rst
@@ -9,12 +9,16 @@ crypto
 
 .. automodule:: mitm.crypto
 
------
+----
 
 .. automethod:: mitm.crypto.new_RSA
 
 .. automethod:: mitm.crypto.new_X509
 
-.. autoclass:: mitm.crypto.CertificateAuthority
+----
 
-.. automethod:: mitm.crypto.new_ssl_context
+.. autodata:: mitm.crypto.LRU_MAX_SIZE
+    :annotation:
+
+.. autoclass:: mitm.crypto.CertificateAuthority
+    :members:

--- a/mitm/core.py
+++ b/mitm/core.py
@@ -285,7 +285,7 @@ class Protocol(ABC):  # pragma: no cover
 
     def __init__(
         self,
-        certificate_authority: CertificateAuthority = CertificateAuthority(),
+        certificate_authority: Optional[CertificateAuthority] = None,
         middlewares: List[Middleware] = [],
     ):
         """
@@ -295,7 +295,7 @@ class Protocol(ABC):  # pragma: no cover
             certificate_authority: The certificate authority to use for the connection.
             middlewares: The middlewares to use for the connection.
         """
-        self.certificate_authority = certificate_authority
+        self.certificate_authority = certificate_authority if certificate_authority else CertificateAuthority()
         self.middlewares = middlewares
 
     @abstractmethod

--- a/mitm/extension/protocol.py
+++ b/mitm/extension/protocol.py
@@ -9,7 +9,6 @@ from httpq import Request
 from toolbox.asyncio.streams import tls_handshake
 
 from mitm.core import Connection, Flow, Host, InvalidProtocol, Protocol
-from mitm.crypto import new_ssl_context
 
 
 class HTTP(Protocol):
@@ -93,9 +92,8 @@ class HTTP(Protocol):
             connection.client.writer.write(b"HTTP/1.1 200 OK\r\n\r\n")
             await connection.client.writer.drain()
 
-            # Creates a copy of the destination server X509 certificate.
-            cert, key = self.certificate_authority.new_X509(host)
-            ssl_context = new_ssl_context(cert, key)
+            # Generates new context specific to the host.
+            ssl_context = self.certificate_authority.new_context(host)
 
             # Perform handshake.
             try:

--- a/tests/test_crypto.py
+++ b/tests/test_crypto.py
@@ -66,13 +66,11 @@ class Test_CertificateAuthority:
             assert isinstance(cert.get_pubkey(), OpenSSL.crypto.PKey)
             assert isinstance(key, OpenSSL.crypto.PKey)
 
+    def test_new_context(self):
+        with tempfile.TemporaryDirectory() as directory:
+            path = Path(directory)
+            ca = crypto.CertificateAuthority.init(path)
 
-def test_new_ssl_context():
-    with tempfile.TemporaryDirectory() as directory:
-        path = Path(directory)
-        ca = crypto.CertificateAuthority.init(path)
-        cert, key = ca.new_X509("example.com")
-
-        # Creates a new SSL context.
-        context = crypto.new_ssl_context(cert, key)
-        assert isinstance(context, ssl.SSLContext)
+            # Creates a new SSL context.
+            context = ca.new_context("example.com")
+            assert isinstance(context, ssl.SSLContext)


### PR DESCRIPTION
As mentioned by #18, `mitm` has a bottleneck that does not allow it to be used in conjunction with normal web use. 

This PR increases performance by caching `ssl.SSLContext` that are generated by `mitm` so that it does not have to save/load from disk on every request.